### PR TITLE
KB-11557 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the cb-notification-wrapper service.

### DIFF
--- a/src/main/java/com/igot/cb/util/PayloadValidation.java
+++ b/src/main/java/com/igot/cb/util/PayloadValidation.java
@@ -20,40 +20,41 @@ import java.util.Set;
 @Service
 public class PayloadValidation {
 
-  private Logger logger = LoggerFactory.getLogger(PayloadValidation.class);
+    private Logger logger = LoggerFactory.getLogger(PayloadValidation.class);
 
     private final JsonSchemaFactory schemaFactory;
 
     public PayloadValidation(JsonSchemaFactory schemaFactory) {
         this.schemaFactory = schemaFactory;
     }
-  public void validatePayload(String fileName, JsonNode payload) {
-   log.info("PayloadValidation::validatePayload:inside");
-      try (InputStream schemaStream = getClass().getResourceAsStream(fileName)) {
-          JsonSchema schema = schemaFactory.getSchema(schemaStream);
-          if (payload.isArray()) {
-        for (JsonNode objectNode : payload) {
-          validateObject(schema, objectNode);
-        }
-      } else{
-        validateObject(schema, payload);
-      }
-    } catch (Exception e) {
-      logger.error("Failed to validate payload", e);
-      throw new CustomException("Failed to validate payload", e.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-  }
 
-  private void validateObject(JsonSchema schema, JsonNode objectNode) {
-    Set<ValidationMessage> validationMessages = schema.validate(objectNode);
-    if (!validationMessages.isEmpty()) {
-      StringBuilder errorMessage = new StringBuilder("Validation error(s): \n");
-      for (ValidationMessage message : validationMessages) {
-        errorMessage.append(message.getMessage()).append("\n");
-      }
-      logger.error("Validation Error", errorMessage.toString());
-      throw new CustomException("Validation Error", errorMessage.toString(), HttpStatus.BAD_REQUEST);
+    public void validatePayload(String fileName, JsonNode payload) {
+        log.info("PayloadValidation::validatePayload:inside");
+        try (InputStream schemaStream = getClass().getResourceAsStream(fileName)) {
+            JsonSchema schema = schemaFactory.getSchema(schemaStream);
+            if (payload.isArray()) {
+                for (JsonNode objectNode : payload) {
+                    validateObject(schema, objectNode);
+                }
+            } else {
+                validateObject(schema, payload);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to validate payload", e);
+            throw new CustomException("Failed to validate payload", e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
     }
-  }
+
+    private void validateObject(JsonSchema schema, JsonNode objectNode) {
+        Set<ValidationMessage> validationMessages = schema.validate(objectNode);
+        if (!validationMessages.isEmpty()) {
+            StringBuilder errorMessage = new StringBuilder("Validation error(s): \n");
+            for (ValidationMessage message : validationMessages) {
+                errorMessage.append(message.getMessage()).append("\n");
+            }
+            logger.error("Validation Error", errorMessage.toString());
+            throw new CustomException("Validation Error", errorMessage.toString(), HttpStatus.BAD_REQUEST);
+        }
+    }
 }
 

--- a/src/main/java/com/igot/cb/util/PayloadValidation.java
+++ b/src/main/java/com/igot/cb/util/PayloadValidation.java
@@ -1,9 +1,11 @@
 package com.igot.cb.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.exceptions.CustomException;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -20,13 +22,16 @@ public class PayloadValidation {
 
   private Logger logger = LoggerFactory.getLogger(PayloadValidation.class);
 
+    private final JsonSchemaFactory schemaFactory;
+
+    public PayloadValidation(JsonSchemaFactory schemaFactory) {
+        this.schemaFactory = schemaFactory;
+    }
   public void validatePayload(String fileName, JsonNode payload) {
    log.info("PayloadValidation::validatePayload:inside");
-    try {
-      JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance();
-      InputStream schemaStream = schemaFactory.getClass().getResourceAsStream(fileName);
-      JsonSchema schema = schemaFactory.getSchema(schemaStream);
-      if (payload.isArray()) {
+      try (InputStream schemaStream = getClass().getResourceAsStream(fileName)) {
+          JsonSchema schema = schemaFactory.getSchema(schemaStream);
+          if (payload.isArray()) {
         for (JsonNode objectNode : payload) {
           validateObject(schema, objectNode);
         }

--- a/src/test/java/com/igot/cb/util/PayloadValidationTest.java
+++ b/src/test/java/com/igot/cb/util/PayloadValidationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.exceptions.CustomException;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,56 +27,52 @@ class PayloadValidationTest {
 
     @BeforeEach
     void setUp() {
-        payloadValidation = new PayloadValidation();
+        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
+        payloadValidation = new PayloadValidation(schemaFactory);
         mapper = new ObjectMapper();
     }
 
     @Test
     void testValidatePayload_validObject() throws Exception {
         JsonNode payload = mapper.readTree("{\"name\":\"John\"}");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
         JsonSchema schema = mock(JsonSchema.class);
-        when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(Collections.emptySet());
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            payloadValidation.validatePayload("/valid-schema.json", payload);
-        }
+        JsonSchemaFactory schemaFactorytest = mock(JsonSchemaFactory.class);
+        when(schemaFactorytest.getSchema(any(InputStream.class))).thenReturn(schema);
+        PayloadValidation payloadValidationtest = new PayloadValidation(schemaFactorytest);
+        payloadValidationtest.validatePayload("/valid-schema.json", payload);
+        verify(schema).validate(payload);
     }
 
+
     @Test
-    void testValidatePayload_validArray() throws Exception {
+    void testValidatePayload_validArray_realSchema() throws Exception {
         JsonNode payload = mapper.readTree("[{\"name\":\"John\"}, {\"name\":\"Jane\"}]");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
-        JsonSchema schema = mock(JsonSchema.class);
-        when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
-        when(schema.validate(any(JsonNode.class))).thenReturn(Collections.emptySet());
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            payloadValidation.validatePayload("/valid-schema.json", payload);
-        }
+        PayloadValidation payloadValidationtest = new PayloadValidation(
+                JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                        .objectMapper(new ObjectMapper())
+                        .build()
+        );
+        payloadValidationtest.validatePayload("/valid-schema.json", payload);
     }
 
     @Test
     void testValidatePayload_invalidObject() throws Exception {
         JsonNode payload = mapper.readTree("{\"name\":123}");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
         JsonSchema schema = mock(JsonSchema.class);
         ValidationMessage mockMessage = mock(ValidationMessage.class);
         when(mockMessage.getMessage()).thenReturn("Type mismatch");
-        Set<ValidationMessage> errors = new HashSet<>();
-        errors.add(mockMessage);
-        when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
+        Set<ValidationMessage> errors = Set.of(mockMessage);
         when(schema.validate(any(JsonNode.class))).thenReturn(errors);
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            CustomException ex = assertThrows(CustomException.class, () ->
-                    payloadValidation.validatePayload("/valid-schema.json", payload));
-            assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
-            assertTrue(ex.getMessage().contains("Type mismatch"));
-        }
-    }
+        JsonSchemaFactory schemaFactorytest = mock(JsonSchemaFactory.class);
+        when(schemaFactorytest.getSchema(any(InputStream.class))).thenReturn(schema);
+        PayloadValidation payloadValidationtest = new PayloadValidation(schemaFactorytest);
+        CustomException ex = assertThrows(CustomException.class, () ->
+                payloadValidationtest.validatePayload("/valid-schema.json", payload));
 
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
+        assertTrue(ex.getMessage().contains("Type mismatch"));
+    }
 
     @Test
     void testValidatePayload_invalidArray() throws Exception {

--- a/src/test/java/com/igot/cb/util/PropertiesCacheTest.java
+++ b/src/test/java/com/igot/cb/util/PropertiesCacheTest.java
@@ -2,13 +2,11 @@ package com.igot.cb.util;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class PropertiesCacheTest {
 


### PR DESCRIPTION
1. Remove this use of "getInstance"; it is deprecated.
2. Remove this unused import 'org.mockito.MockedStatic'.
3. Remove this unused import 'org.mockito.Mockito'.