### PR TITLE
KB-11557 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the cb-notification-wrapper service.

### DIFF
--- a/src/main/java/com/igot/cb/util/PayloadValidation.java
+++ b/src/main/java/com/igot/cb/util/PayloadValidation.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.igot.cb.exceptions.CustomException;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ public class PayloadValidation {
   public void validatePayload(String fileName, JsonNode payload) {
    log.info("PayloadValidation::validatePayload:inside");
     try {
-      JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance();
+      JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
       InputStream schemaStream = schemaFactory.getClass().getResourceAsStream(fileName);
       JsonSchema schema = schemaFactory.getSchema(schemaStream);
       if (payload.isArray()) {

--- a/src/test/java/com/igot/cb/util/PayloadValidationTest.java
+++ b/src/test/java/com/igot/cb/util/PayloadValidationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.exceptions.CustomException;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,8 @@ class PayloadValidationTest {
         when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(Collections.emptySet());
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             payloadValidation.validatePayload("/valid-schema.json", payload);
         }
     }
@@ -51,7 +53,8 @@ class PayloadValidationTest {
         when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(Collections.emptySet());
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             payloadValidation.validatePayload("/valid-schema.json", payload);
         }
     }
@@ -68,7 +71,8 @@ class PayloadValidationTest {
         when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(errors);
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             CustomException ex = assertThrows(CustomException.class, () ->
                     payloadValidation.validatePayload("/valid-schema.json", payload));
             assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
@@ -89,7 +93,8 @@ class PayloadValidationTest {
         when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(errors);
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             CustomException ex = assertThrows(CustomException.class, () ->
                     payloadValidation.validatePayload("/valid-schema.json", payload));
             assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
@@ -104,7 +109,8 @@ class PayloadValidationTest {
         JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
         when(schemaFactory.getSchema(any(InputStream.class))).thenThrow(new RuntimeException("File not found"));
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             CustomException ex = assertThrows(CustomException.class, () ->
                     payloadValidation.validatePayload("/non-existent-schema.json", payload));
             assertEquals("Failed to validate payload", ex.getCode());
@@ -117,7 +123,8 @@ class PayloadValidationTest {
         JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
         when(schemaFactory.getSchema(any(InputStream.class))).thenThrow(new RuntimeException("Unexpected error"));
         try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
+            mocked.when(() -> JsonSchemaFactory.getInstance(any(SpecVersion.VersionFlag.class)))
+                    .thenReturn(schemaFactory);
             assertThrows(CustomException.class, () ->
                     payloadValidation.validatePayload("/valid-schema.json", payload));
         }


### PR DESCRIPTION

1. Remove this use of "getInstance"; it is deprecated.