### PR TITLE
KB-11557 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the cb-notification-wrapper service.

### DIFF
--- a/src/test/java/com/igot/cb/util/PayloadValidationTest.java
+++ b/src/test/java/com/igot/cb/util/PayloadValidationTest.java
@@ -9,7 +9,6 @@ import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 
 import java.io.InputStream;
@@ -24,10 +23,11 @@ class PayloadValidationTest {
 
     private PayloadValidation payloadValidation;
     private ObjectMapper mapper;
+    private JsonSchemaFactory schemaFactory;
 
     @BeforeEach
     void setUp() {
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
+        schemaFactory = mock(JsonSchemaFactory.class);
         payloadValidation = new PayloadValidation(schemaFactory);
         mapper = new ObjectMapper();
     }
@@ -75,9 +75,17 @@ class PayloadValidationTest {
     }
 
     @Test
+    void testValidatePayload_validArray() throws Exception {
+        JsonNode payload = mapper.readTree("[{\"name\":\"John\"}, {\"name\":\"Jane\"}]");
+        JsonSchema schema = mock(JsonSchema.class);
+        when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
+        when(schema.validate(any(JsonNode.class))).thenReturn(Set.of());
+        assertDoesNotThrow(() -> payloadValidation.validatePayload("/valid-schema.json", payload));
+    }
+
+    @Test
     void testValidatePayload_invalidArray() throws Exception {
         JsonNode payload = mapper.readTree("[{\"name\":123}]");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
         JsonSchema schema = mock(JsonSchema.class);
         ValidationMessage mockMessage = mock(ValidationMessage.class);
         when(mockMessage.getMessage()).thenReturn("Type mismatch");
@@ -85,38 +93,27 @@ class PayloadValidationTest {
         errors.add(mockMessage);
         when(schemaFactory.getSchema(any(InputStream.class))).thenReturn(schema);
         when(schema.validate(any(JsonNode.class))).thenReturn(errors);
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            CustomException ex = assertThrows(CustomException.class, () ->
-                    payloadValidation.validatePayload("/valid-schema.json", payload));
-            assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
-        }
+        CustomException ex = assertThrows(CustomException.class, () ->
+                payloadValidation.validatePayload("/valid-schema.json", payload));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getHttpStatusCode());
     }
-
-
 
     @Test
     void testValidatePayload_schemaFileNotFound() throws Exception {
         JsonNode payload = mapper.readTree("{\"name\":\"John\"}");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
-        when(schemaFactory.getSchema(any(InputStream.class))).thenThrow(new RuntimeException("File not found"));
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            CustomException ex = assertThrows(CustomException.class, () ->
-                    payloadValidation.validatePayload("/non-existent-schema.json", payload));
-            assertEquals("Failed to validate payload", ex.getCode());
-        }
+        when(schemaFactory.getSchema(any(InputStream.class)))
+                .thenThrow(new RuntimeException("File not found"));
+        CustomException ex = assertThrows(CustomException.class, () ->
+                payloadValidation.validatePayload("/non-existent-schema.json", payload));
+        assertEquals("Failed to validate payload", ex.getCode());
     }
 
     @Test
     void testValidatePayload_exceptionDuringValidation() throws Exception {
         JsonNode payload = mapper.readTree("{\"name\":\"John\"}");
-        JsonSchemaFactory schemaFactory = mock(JsonSchemaFactory.class);
-        when(schemaFactory.getSchema(any(InputStream.class))).thenThrow(new RuntimeException("Unexpected error"));
-        try (var mocked = Mockito.mockStatic(JsonSchemaFactory.class)) {
-            mocked.when(JsonSchemaFactory::getInstance).thenReturn(schemaFactory);
-            assertThrows(CustomException.class, () ->
-                    payloadValidation.validatePayload("/valid-schema.json", payload));
-        }
+        when(schemaFactory.getSchema(any(InputStream.class)))
+                .thenThrow(new RuntimeException("Unexpected error"));
+        assertThrows(CustomException.class, () ->
+                payloadValidation.validatePayload("/valid-schema.json", payload));
     }
 }


### PR DESCRIPTION


1. Remove this use of "getInstance"; it is deprecated.